### PR TITLE
feat: bump kv merkle tree version

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sismo-core/hydra-s3",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Hydra S3 Proving scheme",
   "license": "MIT",
   "author": "Sismo core",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sismo-core/hydra-s3",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Hydra S3 Proving scheme",
   "license": "MIT",
   "author": "Sismo core",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@sismo-core/crypto": "^1.1.4",
-    "@sismo-core/kv-merkle-tree": "^1.0.4",
+    "@sismo-core/kv-merkle-tree": "^1.1.0",
     "snarkjs": "^0.7.0"
   },
   "publishConfig": {

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -444,13 +444,14 @@
     circomlibjs "^0.1.2"
     ethers "^5.6.1"
 
-"@sismo-core/kv-merkle-tree@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@sismo-core/kv-merkle-tree/-/kv-merkle-tree-1.0.4.tgz#c2ad6e89fc9b4ff235bea1efdbaad9ff92271ffa"
-  integrity sha512-FBIT4DuRngTZJxo0Z1L5MGb1LxK3VN9yZy6TloXQDz20j3QpTmb/hO6nfZ3pEROOwmgzlxZ3ZAHSXHx3uNJBOg==
+"@sismo-core/kv-merkle-tree@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@sismo-core/kv-merkle-tree/-/kv-merkle-tree-1.1.0.tgz#135e4f79c235d5551acdb5664a5dccc057ae6af4"
+  integrity sha512-YsoysN9c/iSsA0mhheYWPF/VEhB6GrZCB3fTFy2m7G+gfPD+xAY8Ffyf1pJ0kf5zc4ENkE1YPS8JqlWaLVWTvA==
   dependencies:
     "@sismo-core/crypto" "^1.0.1"
     ethers "^5.6.1"
+    pako "^2.1.0"
     tslib "^2.4.0"
 
 "@types/estree@*":
@@ -982,6 +983,11 @@ once@^1.3.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+pako@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Bump version of the kv merkle tree to be compatible with https://github.com/sismo-core/sismo-utils/pull/2 